### PR TITLE
chore: bump GitHub Actions to latest (checkout v6)

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: GitHub Release
         id: github-release
         uses: foundryvtt-dcc/foundry-release-action@main

--- a/.github/workflows/foundry-website-update.yml
+++ b/.github/workflows/foundry-website-update.yml
@@ -14,7 +14,7 @@ jobs:
     name: Foundry Website Update
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main

--- a/.github/workflows/update-foundry-manifest-after-release.yml
+++ b/.github/workflows/update-foundry-manifest-after-release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main


### PR DESCRIPTION
## Summary
- actions/checkout -> v6

## Test plan
- [ ] CI passes on this PR
- [ ] Verify release workflow runs end-to-end on next release